### PR TITLE
Deleting temporary snapshot after Deleting temporary volume finished. Concerning to bug 2013258

### DIFF
--- a/freezer/openstack/backup.py
+++ b/freezer/openstack/backup.py
@@ -77,12 +77,12 @@ class BackupOs(object):
         if attachments:
             headers['server'] = attachments[0]['server_id']
         self.storage.add_stream(stream, package, headers=headers)
-        LOG.debug("Deleting temporary snapshot")
-        client_manager.clean_snapshot(snapshot)
         LOG.debug("Deleting temporary volume")
         cinder.volumes.delete(copied_volume)
         LOG.debug("Deleting temporary image")
         client_manager.get_glance().images.delete(image.id)
+        LOG.debug("Deleting temporary snapshot")
+        client_manager.clean_snapshot(snapshot)
 
     def backup_cinder(self, volume_id, name=None, description=None,
                       incremental=False):


### PR DESCRIPTION
Deleting temporary snapshot after Deleting temporary volume finished. Concerning to bug: https://bugs.launchpad.net/freezer/+bug/2013258

[comment]
Since the volume depends on the snapshot (it's created by snapshot with clone on CEPH, without flatten), deleting snapshot can't be done before volume is deleted.

[cinder-volume.log]
2023-03-20 17:32:35.800 34 ERROR cinder.volume.manager [req-d849f7ff-b8fa-4ca0-ad80-42298e87217f req-89e993fc-7837-451b-aa27-d72694a4aa1d@global_request_id 5ca52b5e65df4d879dd490afa350a3f0 76e23046831943bba571f0e3ea432182 - default default] Delete snapshot failed, due to snapshot busy.: SnapshotIsBusy: deleting snapshot snapshot-a540413c-72a9-4cde-8bea-a29b2ce7a012 that has dependent volumes

[cinder-volume.log]
2023-03-27 11:59:19.145 34 ERROR cinder.volume.manager [req-39f7e290-29f3-4e5d-b9c2-d6e96867ed51 req-f552a927-f882-48d0-9809-564acb73e121@global_request_id 5ca52b5e65df4d879dd490afa350a3f0 76e23046831943bba571f0e3ea432182 - default default] Delete snapshot failed, due to snapshot busy.: SnapshotIsBusy: deleting snapshot snapshot-561e441f-7e02-4f30-92b4-f0b00cacdcac that has dependent volumes

[Improvement Suggestion]
(delete temporary volume at first)
  delete volume => delete image => delete snapshot